### PR TITLE
fix!: use correct well-known TD URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You can choose between the multicast addresses for all IPv4/IPv6 nodes or the re
 
 Supported methods for CoAP so far include:
 
-- Discovery from `/.well-known/wot-thing-discription`.
+- Discovery from `/.well-known/wot`.
 - Discovery using the CoRE Link Format and `/.well-known/core` (the correct content type and resource type has to be set in the list of links).
 - Discovery from CoRE Resource Directories. For this method, available Resource Directories are discovered first which are then queried for links pointing to TDs.
 

--- a/nodes/wot-discovery.html
+++ b/nodes/wot-discovery.html
@@ -247,7 +247,7 @@
                 style="display: inline-block; width: auto; vertical-align: top;"
                 />
                 <label for="node-input-tdURI" style="width: auto">
-                    Discover from <code>/.well-known/wot-thing-description</code>
+                    Discover from <code>/.well-known/wot</code>
                 </label>
             </div>
             <div>

--- a/nodes/wot-discovery.js
+++ b/nodes/wot-discovery.js
@@ -131,7 +131,7 @@ module.exports = function (RED) {
 
       coapAddresses.forEach(address => {
         if (tdURI) {
-          _sendCoapDiscovery(address, '/.well-known/wot-thing-description')
+          _sendCoapDiscovery(address, '/.well-known/wot')
         }
         if (coreURI) {
           _getDiscoveryLinks(address)

--- a/nodes/wot-fetch.html
+++ b/nodes/wot-fetch.html
@@ -48,7 +48,7 @@
     </div>
     <div class="form-row">
         <label for="node-input-tdUrl"><i class="fa fa-file"></i> TD URL</label>
-        <input type="text" id="node-input-tdUrl" placeholder="http://example.org/.well-known/wot-thing-description" />
+        <input type="text" id="node-input-tdUrl" placeholder="http://example.org/.well-known/wot" />
     </div>
 
     <div class="form-row node-input-outputVar-row">


### PR DESCRIPTION
The well-known URI `/.well-known/wot-thing-discription` has been changed to /.well-known/wot` in the meantime. This PR incorporates this change, making the package specification-compliant again.